### PR TITLE
ModelSerializers Support

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -8,6 +8,8 @@ _LOG = logging.getLogger(f"django-typomatic.{__name__}")
 __serializers = dict()
 # Custom serializers.Field to TS Type mappings
 __field_mappings = dict()
+# Custom field_name to TS Type overrides
+__mapping_overrides = dict()
 
 def ts_field(ts_type: str, context='default'):
     '''
@@ -31,26 +33,35 @@ def ts_field(ts_type: str, context='default'):
         return cls
     return decorator
 
-def ts_interface(context='default'):
+def ts_interface(context='default', mapping_overrides=None):
     '''
     Any valid Django Rest Framework Serializers with this class decorator will
-    be added to a list in a dictionary. An optional parameter: 'context'
-    may be provided, which will create separate dictionary keys per context.
-    Otherwise, all values will be inserted into a list with a key of 'default'.
+    be added to a list in a dictionary.
+    Optional parameters:
+    'context': Will create separate dictionary keys per context.
+        Otherwise, all values will be inserted into a list with a key of 'default'.
+    'mapping_overrides': Dictionary of field_names to TS types
+        Useful to properly serialize ModelSerializer runtime properties and ReadOnlyFields.
     e.g.
-    @ts_interface(context='internal')
+    @ts_interface(context='internal', mapping_overrides={"baz" : "string[]"})
     class Foo(serializers.Serializer):
         bar = serializer.IntegerField()
+        baz = serializer.ReadOnlyField(source='baz_property')
     '''
     def decorator(cls):
         if issubclass(cls, serializers.Serializer):
             if context not in __serializers:
                 __serializers[context] = []
             __serializers[context].append(cls)
+            if mapping_overrides:
+                if context not in __mapping_overrides:
+                    __mapping_overrides[context] = dict()
+                if cls not in __mapping_overrides[context]:
+                    __mapping_overrides[context][cls] = mapping_overrides
         return cls
     return decorator
 
-def __process_field(field_name, field, context):
+def __process_field(field_name, field, context, serializer):
     '''
     Generates and returns a tuple representing the Typescript field name and Type.
     '''
@@ -60,6 +71,8 @@ def __process_field(field_name, field, context):
         ts_type = field_type.__name__
     elif field_type in __field_mappings[context]:
         ts_type = __field_mappings[context].get(field_type, 'any')
+    elif (context in __mapping_overrides) and (serializer in __mapping_overrides[context]) and field_name in __mapping_overrides[context][serializer]:
+        ts_type = __mapping_overrides[context][serializer].get(field_name, 'any')
     else:
         ts_type = mappings.get(field_type, 'any')
     if is_many:
@@ -83,7 +96,7 @@ def __get_ts_interface(serializer, context):
         fields = serializer._declared_fields.items()
     ts_fields = []
     for key, value in fields:
-        ts_field = __process_field(key, value, context)
+        ts_field = __process_field(key, value, context, serializer)
         ts_fields.append(f"    {ts_field[0]}: {ts_field[1]};")
     collapsed_fields = '\n'.join(ts_fields)
     return f'export interface {name} {{\n{collapsed_fields}\n}}\n\n'

--- a/django_typomatic/mappings.py
+++ b/django_typomatic/mappings.py
@@ -15,9 +15,9 @@ mappings = {
     serializers.IntegerField: 'number',
     serializers.FloatField: 'number',
     serializers.DecimalField: 'number',
-    serializers.DateTimeField: 'Date',
-    serializers.DateField: 'Date',
-    serializers.TimeField: 'Date',
-    serializers.DurationField: 'Date',
+    serializers.DateTimeField: 'string',
+    serializers.DateField: 'string',
+    serializers.TimeField: 'string',
+    serializers.DurationField: 'string',
     serializers.DictField: 'Map'
 }

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+
+PYTHON_VERSION="3.6.8"
+VIRTUAL_ENV_NAME="django-typomatic"
+
+# Create the virtual environment and set it as the one to use
+echo "Creating pyenv virtual environment and installing packages..."
+pyenv install --skip-existing "${PYTHON_VERSION}"
+pyenv virtualenv "${PYTHON_VERSION}" "${VIRTUAL_ENV_NAME}"
+pyenv local "${VIRTUAL_ENV_NAME}" system

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as file:
 
 setuptools.setup(
     name="django-typomatic",
-    version="0.0.1",
+    version="0.0.2",
     url="https://github.com/adenh93/django_typomatic",
 
     author="Aden Herold",
@@ -24,6 +24,6 @@ setuptools.setup(
 
     install_requires=[
         'django',
-        'django_rest_framework'
+        'djangorestframework'
     ]
 )


### PR DESCRIPTION
Adding Support for:
- ModelSerializers
- Custom serializers.Field
- Field mapping overrides, needed by ReadOnlyField to map correctly

Also:
- Updating **django_rest_framework** dependency
- Adding init.sh script to automatically create pyenv environment, useful for local dev.

Fixing:
- DateField, DateTimeField, etc. were being serialized to Date objects, but they are actually serialized to ISO-8601 strings, and is up to the consumer to parse them correctly; possibly with the native Date object or even better: Moment.js.

Also, if you are looking for maintainers, I would gladly do it!