### PR TITLE
Fix typo for project URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as file:
 setuptools.setup(
     name="django-typomatic",
     version="0.0.2",
-    url="https://github.com/adenh93/django_typomatic",
+    url="https://github.com/adenh93/django-typomatic",
 
     author="Aden Herold",
     author_email="aden.herold1@gmail.com",


### PR DESCRIPTION
I noticed that the URL as written 404ed when following it here https://pypi.org/project/django-typomatic/. Fixing by replacing `_` with `-`.

Side note: thanks for putting together this package. Excited to try it out soon!