### PR TITLE
Use `unknown` instead of `any` as the value to fallback to when the type is not known

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -78,7 +78,7 @@ def __map_choices_to_union(field_type, choices):
     '''
     if not choices:
         _LOG.warning(f'No choices specified for Serializer Field: {field_type}')
-        return 'any'
+        return 'unknown'
 
     return ' | '.join(f'"{key}"' if type(key) == str else str(key) for key in choices.keys())
 
@@ -89,7 +89,7 @@ def __map_choices_to_enum(enum_name, field_type, choices):
     '''
     if not choices:
         _LOG.warning(f'No choices specified for Serializer Field: {field_type}')
-        return 'any'
+        return 'unknown'
 
     choices_enum = f"export enum {enum_name} {{\n"
     for key, value in choices.items():
@@ -120,11 +120,11 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
         ts_type = __get_trimmed_name(
             field_type.__name__, trim_serializer_output)
     elif field_type in __field_mappings[context]:
-        ts_type = __field_mappings[context].get(field_type, 'any')
+        ts_type = __field_mappings[context].get(field_type, 'unknown')
     elif (context in __mapping_overrides) and (serializer in __mapping_overrides[context]) \
             and field_name in __mapping_overrides[context][serializer]:
         ts_type = __mapping_overrides[context][serializer].get(
-            field_name, 'any')
+            field_name, 'unknown')
     elif field_type == serializers.PrimaryKeyRelatedField:
         ts_type = "number | string"
     elif hasattr(field, 'choices') and enum_choices:
@@ -133,7 +133,7 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
     elif hasattr(field, 'choices'):
         ts_type = __map_choices_to_union(field_type, field.choices)
     else:
-        ts_type = mappings.get(field_type, 'any')
+        ts_type = mappings.get(field_type, 'unknown')
     if is_many:
         ts_type += '[]'
 


### PR DESCRIPTION
Resolves #29 

`unknown` was introduced in TypeScript v3. You can read more on the PR [here](https://github.com/Microsoft/TypeScript/pull/24439)

Lots to read but the main part is that `any` is _too_ permissive and should be avoided or you can get some fun stuff like:

```ts
const anyVar: any = 'foo'
myVar.method() // does not trigger the linter, it should.

const unknownVar: unknown = 'bar'
unknownVar.method() // triggers the linter
```