### PR TITLE
feat: annotations

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -215,7 +215,8 @@ def __get_enums_and_interfaces_from_generated(interfaces_enums):
 def __get_annotations(field, ts_type):
     annotations = []
     annotations.append('    /**')
-    annotations.append(f'    * @label {field.label}')
+    if field.label:
+        annotations.append(f'    * @label {field.label}')
 
     default = field.default if field.default != empty else None
 
@@ -224,11 +225,6 @@ def __get_annotations(field, ts_type):
             annotations.append(f'    * @minLength {field.min_length}')
         if getattr(field, 'max_length', None):
             annotations.append(f'    * @maxLength {field.max_length}')
-
-        field_type = type(field)
-
-        if field_type in format_mappings:
-            annotations.append(f'    * @format {format_mappings[field_type]}')
 
         if default is not None and 'number | string' not in ts_type:
             annotations.append(f'    * @default "{default}"')
@@ -241,6 +237,11 @@ def __get_annotations(field, ts_type):
 
         if default is not None:
             annotations.append(f'    * @default {default}')
+
+    field_type = type(field)
+
+    if field_type in format_mappings:
+        annotations.append(f'    * @format {format_mappings[field_type]}')
 
     annotations.append('    */')
 

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -214,7 +214,7 @@ def __get_enums_and_interfaces_from_generated(interfaces_enums):
 def __get_annotations(field, ts_type):
     annotations = []
     annotations.append('    /**')
-    annotations.append(f'    * {field.label}')
+    annotations.append(f'    * @label {field.label}')
 
     default = field.default if field.default != empty else None
 

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -1,7 +1,9 @@
 import logging
-from rest_framework import serializers
-from .mappings import mappings
 
+from rest_framework import serializers
+from rest_framework.fields import empty
+
+from .mappings import mappings
 
 _LOG = logging.getLogger(f"django-typomatic.{__name__}")
 
@@ -26,6 +28,7 @@ def ts_field(ts_type: str, context='default'):
         def to_representation(self, obj):
             pass
     '''
+
     def decorator(cls):
         if issubclass(cls, serializers.Field):
             if context not in __field_mappings:
@@ -33,6 +36,7 @@ def ts_field(ts_type: str, context='default'):
             if cls not in __field_mappings[context]:
                 __field_mappings[context][cls] = ts_type
         return cls
+
     return decorator
 
 
@@ -51,6 +55,7 @@ def ts_interface(context='default', mapping_overrides=None):
         bar = serializer.IntegerField()
         baz = serializer.ReadOnlyField(source='baz_property')
     '''
+
     def decorator(cls):
         if issubclass(cls, serializers.Serializer):
             if context not in __field_mappings:
@@ -64,6 +69,7 @@ def ts_interface(context='default', mapping_overrides=None):
                 if cls not in __mapping_overrides[context]:
                     __mapping_overrides[context][cls] = mapping_overrides
         return cls
+
     return decorator
 
 
@@ -174,6 +180,9 @@ def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, ca
         if value.allow_null:
             ts_type = ts_type + " | null"
 
+        annotations = __get_annotations(value, ts_type)
+
+        ts_fields.append('\n'.join(annotations))
         ts_fields.append(f"    {ts_property}: {ts_type};")
     collapsed_fields = '\n'.join(ts_fields)
     return f'export interface {name} {{\n{collapsed_fields}\n}}\n\n', enums
@@ -200,6 +209,50 @@ def __get_enums_and_interfaces_from_generated(interfaces_enums):
         distinct_enums = sorted(list(set(list(filter(lambda x: x is not None, flat_enums)))))
         enums_string = '\n'.join(distinct_enums) + '\n\n'
     return enums_string, interfaces
+
+
+def __get_annotations(field, ts_type):
+    annotations = []
+    annotations.append('    /**')
+    annotations.append(f'    {field.label}')
+
+    default = field.default if field.default != empty else None
+
+    if 'string' in ts_type:
+        if getattr(field, 'min_length', None):
+            annotations.append(f'    * @minLength {field.min_length}')
+        if getattr(field, 'max_length', None):
+            annotations.append(f'    * @maxLength {field.max_length}')
+
+        type_mapping_format = {
+            "<class 'rest_framework.fields.EmailField'>": '* @format email',
+            "<class 'rest_framework.fields.URLField'>": '* @format url',
+            "<class 'rest_framework.fields.UUIDField'>": '* @format uuid',
+            "<class 'rest_framework.fields.DateTimeField'>": '* @format date-time',
+            "<class 'rest_framework.fields.DateField'>": '* @format date',
+            "<class 'rest_framework.fields.FloatField'>": '* @format double',
+        }
+
+        field_type = str(type(field))
+
+        if field_type in type_mapping_format:
+            annotations.append(f'    {type_mapping_format[field_type]}')
+
+        if default is not None and 'number | string' not in ts_type:
+            annotations.append(f'    @default "{default}"')
+
+    if 'number' in ts_type:
+        if getattr(field, 'min_value', None):
+            annotations.append(f'    * @minimum {field.min_value}')
+        if getattr(field, 'max_value', None):
+            annotations.append(f'    * @maximum {field.max_value}')
+
+        if default is not None:
+            annotations.append(f'    @default {default}')
+
+    annotations.append('    */')
+
+    return annotations
 
 
 def generate_ts(output_path, context='default', trim_serializer_output=False, camelize=False,

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -150,7 +150,7 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
     return field_name, ts_type, ts_enum
 
 
-def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize, enum_choices):
+def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize, enum_choices, annotations):
     '''
     Generates and returns a Typescript Interface by iterating
     through the serializer fields of the DRF Serializer class
@@ -180,19 +180,20 @@ def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, ca
         if value.allow_null:
             ts_type = ts_type + " | null"
 
-        annotations = __get_annotations(value, ts_type)
+        if annotations:
+            annotations_list = __get_annotations(value, ts_type)
+            ts_fields.append('\n'.join(annotations_list))
 
-        ts_fields.append('\n'.join(annotations))
         ts_fields.append(f"    {ts_property}: {ts_type};")
     collapsed_fields = '\n'.join(ts_fields)
     return f'export interface {name} {{\n{collapsed_fields}\n}}\n\n', enums
 
 
-def __generate_interfaces_and_enums(context, trim_serializer_output, camelize, enum_choices):
+def __generate_interfaces_and_enums(context, trim_serializer_output, camelize, enum_choices, annotations):
     if context not in __serializers:
         return []
     return [__get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize,
-                                         enum_choices) for serializer in __serializers[context]]
+                                         enum_choices, annotations) for serializer in __serializers[context]]
 
 
 def __get_enums_and_interfaces_from_generated(interfaces_enums):
@@ -247,7 +248,7 @@ def __get_annotations(field, ts_type):
 
 
 def generate_ts(output_path, context='default', trim_serializer_output=False, camelize=False,
-                enum_choices=False):
+                enum_choices=False, annotations=False):
     '''
     When this function is called, a Typescript interface will be generated
     for each DRF Serializer in the serializers dictionary, depending on the
@@ -259,18 +260,18 @@ def generate_ts(output_path, context='default', trim_serializer_output=False, ca
     '''
     with open(output_path, 'w') as output_file:
         interfaces_enums = __generate_interfaces_and_enums(context, trim_serializer_output,
-                                                           camelize, enum_choices)
+                                                           camelize, enum_choices, annotations)
         enums_string, interfaces = __get_enums_and_interfaces_from_generated(interfaces_enums)
         output_file.write(enums_string + ''.join(interfaces))
 
 
-def get_ts(context='default', trim_serializer_output=False, camelize=False, enum_choices=False):
+def get_ts(context='default', trim_serializer_output=False, camelize=False, enum_choices=False, annotations=False):
     '''
     Similar to generate_ts. But rather than outputting the generated
     interfaces to the specified file, will return the generated interfaces
     as a raw string.
     '''
     interfaces_enums = __generate_interfaces_and_enums(context, trim_serializer_output, camelize,
-                                                       enum_choices)
+                                                       enum_choices, annotations)
     enums_string, interfaces = __get_enums_and_interfaces_from_generated(interfaces_enums)
     return enums_string + ''.join(interfaces)

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -214,7 +214,7 @@ def __get_enums_and_interfaces_from_generated(interfaces_enums):
 def __get_annotations(field, ts_type):
     annotations = []
     annotations.append('    /**')
-    annotations.append(f'    {field.label}')
+    annotations.append(f'    * {field.label}')
 
     default = field.default if field.default != empty else None
 
@@ -227,7 +227,7 @@ def __get_annotations(field, ts_type):
         field_type = type(field)
 
         if field_type in format_mappings:
-            annotations.append(f'   * @format {format_mappings[field_type]}')
+            annotations.append(f'    * @format {format_mappings[field_type]}')
 
         if default is not None and 'number | string' not in ts_type:
             annotations.append(f'    * @default "{default}"')

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -3,7 +3,7 @@ import logging
 from rest_framework import serializers
 from rest_framework.fields import empty
 
-from .mappings import mappings
+from .mappings import mappings, format_mappings
 
 _LOG = logging.getLogger(f"django-typomatic.{__name__}")
 
@@ -224,22 +224,13 @@ def __get_annotations(field, ts_type):
         if getattr(field, 'max_length', None):
             annotations.append(f'    * @maxLength {field.max_length}')
 
-        type_mapping_format = {
-            "<class 'rest_framework.fields.EmailField'>": '* @format email',
-            "<class 'rest_framework.fields.URLField'>": '* @format url',
-            "<class 'rest_framework.fields.UUIDField'>": '* @format uuid',
-            "<class 'rest_framework.fields.DateTimeField'>": '* @format date-time',
-            "<class 'rest_framework.fields.DateField'>": '* @format date',
-            "<class 'rest_framework.fields.FloatField'>": '* @format double',
-        }
+        field_type = type(field)
 
-        field_type = str(type(field))
-
-        if field_type in type_mapping_format:
-            annotations.append(f'    {type_mapping_format[field_type]}')
+        if field_type in format_mappings:
+            annotations.append(f'   * @format {format_mappings[field_type]}')
 
         if default is not None and 'number | string' not in ts_type:
-            annotations.append(f'    @default "{default}"')
+            annotations.append(f'    * @default "{default}"')
 
     if 'number' in ts_type:
         if getattr(field, 'min_value', None):
@@ -248,7 +239,7 @@ def __get_annotations(field, ts_type):
             annotations.append(f'    * @maximum {field.max_value}')
 
         if default is not None:
-            annotations.append(f'    @default {default}')
+            annotations.append(f'    * @default {default}')
 
     annotations.append('    */')
 

--- a/django_typomatic/mappings.py
+++ b/django_typomatic/mappings.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-
 mappings = {
     serializers.BooleanField: 'boolean',
     serializers.CharField: 'string',
@@ -19,4 +18,14 @@ mappings = {
     serializers.TimeField: 'string',
     serializers.DurationField: 'string',
     serializers.DictField: 'Map'
+}
+
+format_mappings = {
+    serializers.EmailField: 'email',
+    serializers.URLField: 'url',
+    serializers.UUIDField: 'uuid',
+    serializers.DateTimeField: 'date-time',
+    serializers.DateField: 'date',
+    serializers.TimeField: 'time',
+    serializers.FloatField: 'double',
 }

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -30,6 +30,19 @@ class OtherSerializer(serializers.Serializer):
     field = serializers.IntegerField()
 
 
+@ts_interface(context='annotations')
+class OtherSerializer(serializers.Serializer):
+    text_field = serializers.CharField(min_length=10, max_length=100, label='Huge Text Field')
+    number_field = serializers.IntegerField(min_value=1, max_value=50)
+    email_field = serializers.EmailField()
+    date_field = serializers.DateField()
+    datetime_field = serializers.DateTimeField()
+    time_field = serializers.TimeField()
+    uuid_field = serializers.UUIDField()
+    url_field = serializers.URLField(default='https://google.com')
+    float_field = serializers.FloatField()
+
+
 class ActionType(models.TextChoices):
     ACTION1 = "Action1", ("Action1")
     ACTION2 = "Action2", ("Action2")
@@ -89,6 +102,7 @@ export interface Bar {
     interfaces = get_ts('internal', trim_serializer_output=True)
     assert interfaces == expected
 
+
 def test_camlize():
     expected = """export interface FooSerializer {
     someField: number[];
@@ -139,4 +153,53 @@ export interface EnumChoiceSerializer {
 
 """
     interfaces = get_ts('enumChoices', enum_choices=True)
+    assert interfaces == expected
+
+
+def test_annotations():
+    expected = """export interface OtherSerializer {
+    /**
+    * @label Huge Text Field
+    * @minLength 10
+    * @maxLength 100
+    */
+    text_field: string;
+    /**
+    * @minimum 1
+    * @maximum 50
+    */
+    number_field: number;
+    /**
+    * @format email
+    */
+    email_field: string;
+    /**
+    * @format date
+    */
+    date_field: string;
+    /**
+    * @format date-time
+    */
+    datetime_field: string;
+    /**
+    * @format time
+    */
+    time_field: string;
+    /**
+    * @format uuid
+    */
+    uuid_field: string;
+    /**
+    * @default "https://google.com"
+    * @format url
+    */
+    url_field?: string;
+    /**
+    * @format double
+    */
+    float_field: number;
+}
+
+"""
+    interfaces = get_ts('annotations', annotations=True)
     assert interfaces == expected


### PR DESCRIPTION
Annotations allow us to bring additional rules for working with fields into the TS structure, for example, a standard value, a minimum length, or a refinement for a string type (email, time, date)
Having such annotations, we can generate a validation structure from this structure (for example, using the ts-to-zod package for js)

Example generate_ts with annotations

```js
export interface UserCreate {
    /**
    * @label ID
    */
    id?: number;
    /**
    * @label Email
    * @maxLength 254
    * @format email
    */
    email?: string;
    /**
    * @label Work place
    */
    workplace: number;
    /**
    * @label Username
    * @maxLength 150
    */
    username: string;
    /**
    * @label Groups
    */
    groups?: number | string[];
    /**
    * @label First name
    * @maxLength 150
    */
    first_name?: string;
    /**
    * @label Last Name
    * @maxLength 150
    */
    last_name?: string;
    /**
    * @label password
    */
    password: string;
    /**
    * @label Restricred Date
    * @format date
    * @default "2024-01-01"
    */
    date_restricted?: string;
}
```

Example generate zod from ts

```js
// Generated by ts-to-zod
import { z } from 'zod';

export const userCreateSchema = z.object({
    id: z.number().optional(),
    email: z.string().max(254).email().optional(),
    workplace: z.number(),
    username: z.string().max(150),
    groups: z.union([z.number(), z.array(z.string())]).optional(),
    first_name: z.string().max(150).optional(),
    last_name: z.string().max(150).optional(),
    password: z.string(),
    date_restricted: z.string().optional().default('2024-01-01'),
});
```