### PR TITLE
feat: values enums

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -115,7 +115,8 @@ def __map_choices_to_enum_values(enum_name, field_type, choices):
         if type(key) == str:
             choices_enum = choices_enum + f"    {str(key).replace(' ', '_')} = '{value}',\n"
         else:
-            choices_enum = choices_enum + f"    {str(key).replace(' ', '_')} = {value},\n"
+            "Number enums not need it"
+            return None
     choices_enum = choices_enum + "}\n"
 
     return choices_enum

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -96,7 +96,7 @@ def __map_choices_to_enum(enum_name, field_type, choices):
         if type(key) == str:
             choices_enum = choices_enum + f"    {str(key).upper().replace(' ', '_')} = '{key}',\n"
         else:
-            choices_enum = choices_enum + f"    {str(key).upper().replace(' ', '_')} = {key},\n"
+            choices_enum = choices_enum + f"    {str(value).upper().replace(' ', '_')} = {key},\n"
     choices_enum = choices_enum + "}\n"
 
     return choices_enum

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -140,3 +140,33 @@ export interface EnumChoiceSerializer {
 """
     interfaces = get_ts('enumChoices', enum_choices=True)
     assert interfaces == expected
+
+
+def test_choices_enum_values():
+    expected = """export enum ActionChoiceEnum {
+    ACTION1 = 'Action1',
+    ACTION2 = 'Action2',
+    ACTION3 = 'Action3',
+}
+
+export enum ActionChoiceEnumValues {
+    Action1 = 'Action1',
+    Action2 = 'Action2',
+    Action3 = 'Action3',
+}
+
+export enum NumChoiceEnum {
+    LOW = 1,
+    MEDIUM = 2,
+    HIGH = 3,
+}
+
+
+export interface EnumChoiceSerializer {
+    action: ActionChoiceEnum;
+    num: NumChoiceEnum;
+}
+
+"""
+    interfaces = get_ts('enumChoices', enum_choices=True, enum_values=True)
+    assert interfaces == expected


### PR DESCRIPTION
I slightly changed the structure of generating basic enums, now the left value from the choice field (key) is taken as the basis for the key, the key value for the enum is made based on it, this is justified by the fact that in the choice fields there is always a system value on the left, and a displayed one on the right, displayed may contain spaces, begin with numbers and other conflicting things that will cause problems during generation

To get the display name conceived on the backend from our enum, I made a new option values enum that allows you to get the display name by key

Previous generated enum, before my fix

Enum example
```python
 class OrganismNumbers(models.TextChoices):
        org1 = 'org1', 'Org 1'
        org2 = 'org2', 'Org 2'
```

Output example
```js
export enum OrganismNumberChoiceEnum {
    ORG 1 = 'org1',
    ORG 2 = 'org2',
}
```
This structure is broken

Output after fix
```js
export enum OrganismNumberChoiceEnum {
    ORG1 = 'org1',
    ORG2 = 'org2',
}
```
Just uppercase the key's value (and replace whitespace just in case)


Example for values enum (by default is switched off)

```js
export enum OrganismNumberChoiceEnumValues {
    org1 = 'Org 1',
    org2 = 'Org 2',
}
```
The second enum let's get us the display name