### PR TITLE
fix: combining enum_values & enum_choices

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -164,6 +164,9 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
             ts_enum = __map_choices_to_enum(ts_type, field_type, field.choices)
         if enum_values:
             ts_enum_value = __map_choices_to_enum_values(f'{ts_type}Values', field_type, field.choices)
+
+            if not enum_choices:
+                ts_type = __map_choices_to_union(field_type, field.choices)
     elif hasattr(field, 'choices'):
         ts_type = __map_choices_to_union(field_type, field.choices)
     else:
@@ -178,7 +181,8 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
     return field_name, ts_type, ts_enum, ts_enum_value
 
 
-def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize, enum_choices, enum_values, annotations):
+def __get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize, enum_choices, enum_values,
+                                 annotations):
     '''
     Generates and returns a Typescript Interface by iterating
     through the serializer fields of the DRF Serializer class
@@ -224,7 +228,8 @@ def __generate_interfaces_and_enums(context, trim_serializer_output, camelize, e
     if context not in __serializers:
         return []
     return [__get_ts_interface_and_enums(serializer, context, trim_serializer_output, camelize,
-                                         enum_choices, enum_values, annotations) for serializer in __serializers[context]]
+                                         enum_choices, enum_values, annotations) for serializer in
+            __serializers[context]]
 
 
 def __get_enums_and_interfaces_from_generated(interfaces_enums):
@@ -301,7 +306,8 @@ def generate_ts(output_path, context='default', trim_serializer_output=False, ca
         output_file.write(enums_string + ''.join(interfaces))
 
 
-def get_ts(context='default', trim_serializer_output=False, camelize=False, enum_choices=False, enum_values=False, annotations=False):
+def get_ts(context='default', trim_serializer_output=False, camelize=False, enum_choices=False, enum_values=False,
+           annotations=False):
     '''
     Similar to generate_ts. But rather than outputting the generated
     interfaces to the specified file, will return the generated interfaces

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -156,7 +156,7 @@ export interface EnumChoiceSerializer {
     assert interfaces == expected
 
 
-def test_choices_enum_values():
+def test_enum_values_with_enum_choices():
     expected = """export enum ActionChoiceEnum {
     ACTION1 = 'Action1',
     ACTION2 = 'Action2',
@@ -234,3 +234,20 @@ def test_annotations():
     interfaces = get_ts('annotations', annotations=True)
     assert interfaces == expected
 
+
+def test_enum_values_without_enum_choices():
+    expected = """export enum ActionChoiceEnumValues {
+    Action1 = 'Action1',
+    Action2 = 'Action2',
+    Action3 = 'Action3',
+}
+
+
+export interface EnumChoiceSerializer {
+    action: "Action1" | "Action2" | "Action3";
+    num: 1 | 2 | 3;
+}
+
+"""
+    interfaces = get_ts('enumChoices', enum_values=True, enum_choices=False)
+    assert interfaces == expected


### PR DESCRIPTION
Fixed incorrect behavior when combining the two options enum_values and enum_choices, now if only enum_values is selected we use union to map our enums inside the type, still leaving us the ability to get the display name of the key through the enum value

Example output before fix (enum_values=True, enum_choices=False)

```js
export enum OrganismNumberChoiceEnumValues {
    org1 = 'Org 1',
    org2 = 'Org 2',
    org3 = 'Org 3',
}

export interface TaskList {
    id?: number;
    organism_number: OrganismNumberChoiceEnum;
}
```
OrganismNumberChoiceEnum is not exist (my fault, sorry)

Example output after fix (enum_values=True, enum_choices=False)
```js
export enum OrganismNumberChoiceEnumValues {
    org1 = 'Org 1',
    org2 = 'Org 2',
    org3 = 'Org 3',
}

export interface TaskList {
    id?: number;
    organism_number: "org1" | "org2" | "org3";
}
```
At now we set union, for combo (enum values without enum choices)

this problem is not critical, you can use these two options together and it will work fine, but if you need variability, when we have enough union enums, but we need a separate structure to get the display name - unfortunately we need this fix

plus 1 test for this case included
