### PR TITLE
Feat method fields serializer return type

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -203,10 +203,10 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
             )
 
             if issubclass(return_type, BaseSerializer):
-                is_external_serializer = return_type.__module__.replace('.serializers', '') == context
+                is_external_serializer = not return_type.__module__.replace('.serializers', '') == context
                 is_serializer_type = True
 
-                if is_external_serializer:
+                if is_external_serializer and return_type not in __serializers.get(context, []):
                     # TODO import external interface, not duplicate
                     # Include external Interface
                     ts_interface(context=context)(return_type)

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -202,6 +202,10 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
                 field_name, field_type, return_type, enum_choices, enum_values, many
             )
 
+            if isinstance(return_type, BaseSerializer):
+                many = return_type.many
+                return_type = return_type.child.__class__
+
             if issubclass(return_type, BaseSerializer):
                 is_external_serializer = not return_type.__module__.replace('.serializers', '') == context
                 is_serializer_type = True

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -78,6 +78,12 @@ class FileSerializer(serializers.Serializer):
 
 
 @ts_interface('methodFields')
+class MethodFieldsNestedSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=15)
+    description = serializers.CharField(max_length=100)
+
+
+@ts_interface('methodFields')
 class MethodFieldsSerializer(serializers.Serializer):
     integer_field = serializers.SerializerMethodField()
     string_field = serializers.SerializerMethodField()
@@ -85,6 +91,7 @@ class MethodFieldsSerializer(serializers.Serializer):
     choice_field = serializers.SerializerMethodField()
     multiple_return = serializers.SerializerMethodField()
     various_type_return = serializers.SerializerMethodField()
+    serializer_type_return = serializers.SerializerMethodField()
 
     def get_integer_field(self) -> int:
         return 5
@@ -103,6 +110,9 @@ class MethodFieldsSerializer(serializers.Serializer):
 
     def get_various_type_return(self) -> [int, str]:
         return random.choice([1, 'test'])
+
+    def get_serializer_type_return(self) -> MethodFieldsNestedSerializer:
+        return MethodFieldsNestedSerializer(name='test', description='Test')
 
 
 def test_get_ts():
@@ -311,6 +321,11 @@ def test_method_fields_serializer():
 }
 
 
+export interface MethodFieldsNestedSerializer {
+    name: string;
+    description: string;
+}
+
 export interface MethodFieldsSerializer {
     integer_field?: number;
     string_field?: string;
@@ -318,6 +333,7 @@ export interface MethodFieldsSerializer {
     choice_field?: ChoiceFieldChoiceEnum;
     multiple_return?: number[];
     various_type_return?: number | string;
+    serializer_type_return?: MethodFieldsNestedSerializer;
 }
 
 """


### PR DESCRIPTION
Now you can specify the return value as another serializer

Test case example

```python
class MethodFieldsNestedSerializer(serializers.Serializer):
    name = serializers.CharField(max_length=15)
    description = serializers.CharField(max_length=100)

class MethodFieldsSerializer(serializers.Serializer):
    serializer_type_return = serializers.SerializerMethodField()

    def get_serializer_type_return(self) -> MethodFieldsNestedSerializer:
        return MethodFieldsNestedSerializer(name='test', description='Test')
```

Output

```js
export interface MethodFieldsSerializer {
    serializer_type_return?: MethodFieldsNestedSerializer;
}

export interface MethodFieldsNestedSerializer {
    name: string;
    description: string;
}
```

many=True support
eg.

```python
def get_serializer_type_return(self) -> MethodFieldsNestedSerializer(many=True):
        return MethodFieldsNestedSerializer(name='test', description='Test')
```

Output
```js
export interface MethodFieldsSerializer {
    serializer_type_return?: MethodFieldsNestedSerializer[];
}
```