### PR TITLE
Feat format decorator

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -82,6 +82,14 @@ def ts_interface(context='default', mapping_overrides=None):
     return decorator
 
 
+def ts_format(format):
+    def decorator(f):
+        f.format = format
+        return f
+
+    return decorator
+
+
 def __get_trimmed_name(name, trim_serializer_output):
     key = "Serializer"
     return name[:-len(key)] if trim_serializer_output and name.endswith(key) else name
@@ -197,7 +205,7 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
                     field_name, field_type, return_type, enum_choices, enum_values, many
                 )
                 types.append(ts_type)
-        else:
+        elif return_type:
             ts_type, ts_enum, ts_enum_value = __process_method_field(
                 field_name, field_type, return_type, enum_choices, enum_values, many
             )
@@ -222,6 +230,14 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
                 is_many = many
 
             types.append(ts_type)
+        else:
+            ts_type, ts_enum, ts_enum_value = __process_method_field(
+                field_name, field_type, return_type, enum_choices, enum_values, many
+            )
+            types.append(ts_type)
+
+        if hasattr(field_function, 'format'):
+            field.format = field_function.format
 
         # Clear duplicate types
         types = list(dict.fromkeys(types))
@@ -384,6 +400,8 @@ def __get_annotations(field, ts_type):
 
     if field_type in format_mappings:
         annotations.append(f'    * @format {format_mappings[field_type]}')
+    elif hasattr(field, 'format'):
+        annotations.append(f'    * @format {field.format}')
 
     annotations.append('    */')
 

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -203,10 +203,10 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
             )
 
             if issubclass(return_type, BaseSerializer):
-                is_external_serializer = return_type.__module__.replace('.serializers', '') == context
+                is_external_serializer = not return_type.__module__.replace('.serializers', '') == context
                 is_serializer_type = True
 
-                if is_external_serializer:
+                if is_external_serializer and return_type not in __serializers.get(context, []):
                     # TODO import external interface, not duplicate
                     # Include external Interface
                     ts_interface(context=context)(return_type)

--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -202,6 +202,10 @@ def __process_field(field_name, field, context, serializer, trim_serializer_outp
                 field_name, field_type, return_type, enum_choices, enum_values, many
             )
 
+            if isinstance(return_type, BaseSerializer):
+                many = return_type.many
+                return_type = return_type.child.__class__
+
             if issubclass(return_type, BaseSerializer):
                 is_external_serializer = not return_type.__module__.replace('.serializers', '') == context
                 is_serializer_type = True

--- a/django_typomatic/__init__.pyi
+++ b/django_typomatic/__init__.pyi
@@ -1,0 +1,20 @@
+from typing import Literal
+
+FORMATS = Literal[
+    'email',
+    'url',
+    'uuid',
+    'date-time',
+    'date',
+    'time',
+    'double',
+]
+
+def ts_format(format: FORMATS): ...
+def ts_field(ts_type: str, context='default'): ...
+def ts_interface(context='default', mapping_overrides=None): ...
+def generate_ts(output_path, context='default', trim_serializer_output=False, camelize=False,
+                enum_choices=False, enum_values=False, annotations=False): ...
+def get_ts(context='default', trim_serializer_output=False, camelize=False, enum_choices=False, enum_values=False,
+           annotations=False): ...
+

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -1,12 +1,9 @@
-import io
 import random
 from typing import List
 
-import pytest
 from rest_framework import serializers
 from django.db import models
-from unittest.mock import patch, mock_open, MagicMock
-from . import ts_interface, generate_ts, get_ts
+from . import ts_interface, get_ts, ts_format
 
 
 @ts_interface(context='internal')
@@ -45,6 +42,11 @@ class OtherSerializer(serializers.Serializer):
     url_field = serializers.URLField(default='https://google.com')
     float_field = serializers.FloatField()
     empty_annotation = serializers.CharField()
+    custom_format = serializers.SerializerMethodField()
+
+    @ts_format('email')
+    def get_custom_format(self, instance) -> str:
+        return 'test@email.com'
 
 
 class ActionType(models.TextChoices):
@@ -277,6 +279,10 @@ def test_annotations():
     */
     float_field: number;
     empty_annotation: string;
+    /**
+    * @format email
+    */
+    custom_format?: string;
 }
 
 """

--- a/django_typomatic/test__init__.py
+++ b/django_typomatic/test__init__.py
@@ -78,6 +78,12 @@ class FileSerializer(serializers.Serializer):
 
 
 @ts_interface('methodFields')
+class MethodFieldsNestedSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=15)
+    description = serializers.CharField(max_length=100)
+
+
+@ts_interface('methodFields')
 class MethodFieldsSerializer(serializers.Serializer):
     integer_field = serializers.SerializerMethodField()
     string_field = serializers.SerializerMethodField()
@@ -85,6 +91,7 @@ class MethodFieldsSerializer(serializers.Serializer):
     choice_field = serializers.SerializerMethodField()
     multiple_return = serializers.SerializerMethodField()
     various_type_return = serializers.SerializerMethodField()
+    serializer_type_return = serializers.SerializerMethodField()
 
     def get_integer_field(self) -> int:
         return 5
@@ -103,6 +110,9 @@ class MethodFieldsSerializer(serializers.Serializer):
 
     def get_various_type_return(self) -> [int, str]:
         return random.choice([1, 'test'])
+
+    def get_serializer_type_return(self) -> MethodFieldsNestedSerializer:
+        return MethodFieldsNestedSerializer(name='test', description='Test')
 
 
 def test_get_ts():
@@ -311,6 +321,11 @@ def test_method_fields_serializer():
 }
 
 
+export interface MethodFieldsNestedSerializer {
+    name: string;
+    description: string;
+}
+
 export interface MethodFieldsSerializer {
     integer_field?: number;
     string_field?: string;
@@ -318,6 +333,7 @@ export interface MethodFieldsSerializer {
     choice_field?: ChoiceFieldChoiceEnum;
     multiple_return?: number[];
     various_type_return?: number | string;
+    serializer_type_return?: MethodFieldsNestedSerializer;
 }
 
 """


### PR DESCRIPTION
The decorator allows you to specify the format of the field, for specific cases

Example
```python
class OtherSerializer(serializers.Serializer):
    custom_format = serializers.SerializerMethodField()

    @ts_format('email')
    def get_custom_format(self, instance) -> str:
        return 'test@email.com'
```

Output
```js
export interface OtherSerializer {
    /**
    * @format email
    */
    custom_format?: string;
}
```