### PR TITLE
Modify enum value to escape single quotes

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -1,8 +1,6 @@
 import logging
 from pathlib import Path
 
-from .mappings import mappings
-
 from rest_framework import serializers
 from rest_framework.serializers import BaseSerializer
 from rest_framework.fields import empty
@@ -135,6 +133,7 @@ def __map_choices_to_enum_values(enum_name, field_type, choices):
 
     choices_enum = f"export enum {enum_name} {{\n"
     for key, value in choices.items():
+        value = value.replace("'", "\\'")
         if type(key) == str:
             choices_enum = choices_enum + f"    {str(key).replace(' ', '_')} = '{value}',\n"
         else:


### PR DESCRIPTION
Hey love the project, just noticed that strings that have single quotes are not serialized correctly resulting in broken string in the generated type files. In our app we have a generated enum from all of the countries in `django-countries==7.5.1`. Côte d'Ivoire was causing problems because it has a single quote in it thus breaking the string.

I also took the liberty of removing `from .mappings import mappings` because It is re imported a few lines down.