### PR TITLE
fix: filter external modules && quote replace

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -133,7 +133,8 @@ def __map_choices_to_enum_values(enum_name, field_type, choices):
 
     choices_enum = f"export enum {enum_name} {{\n"
     for key, value in choices.items():
-        value = value.replace("'", "\\'")
+        if type(value) == str:
+            value = value.replace("'", "\\'")
         if type(key) == str:
             choices_enum = choices_enum + f"    {str(key).replace(' ', '_')} = '{value}',\n"
         else:

--- a/django_typomatic/management/commands/generate_ts.py
+++ b/django_typomatic/management/commands/generate_ts.py
@@ -129,7 +129,7 @@ class Command(BaseCommand):
         if all:
             for app in apps.get_app_configs():
                 # Filter external modules
-                if str(settings.BASE_DIR.parent) not in app.path:
+                if str(settings.BASE_DIR.parent) not in app.path or '.venv' in app.path:
                     continue
 
                 serializers += self._get_app_serializers(app.name)


### PR DESCRIPTION
Quote replacement may be affected on integer value and raise exception, at now this case fixed.
Added a little bit logic at filter external modules (exclude .venv packages, this folder is kept at the same level as the whole project and it causes problems in determining if the package is external or a project package).