### PR TITLE
Improve filtering of external modules

### DIFF
--- a/django_typomatic/management/commands/generate_ts.py
+++ b/django_typomatic/management/commands/generate_ts.py
@@ -148,8 +148,9 @@ class Command(BaseCommand):
 
         if all:
             for app in apps.get_app_configs():
-                # Filter external modules
-                if str(settings.BASE_DIR.parent) not in app.path or '.venv' in app.path:
+                # Include only modules defined within this django project's
+                # directory
+                if Path(settings.BASE_DIR) not in Path(app.path).parents:
                     continue
 
                 serializers += self._get_app_serializers(app.name)


### PR DESCRIPTION
This commit updates the test through which "external" apps are excluded from type generation. The new code simply filters any apps which are not defined within the current django project's directory i.e. apps will be included only if they are defined within a subfolder of the current django project.

The previous code had the result of including non user-defined apps. The first test of the previous code incorrectly filtered on the django project's _parent_ directory, rather than the django project's own directory. The alternative test for being defined within a virtual environment was also too restrictive (and hence, included non-user-defined apps) because virtual environments don't have to have .venv in their path. In any case, once apps are correctly filtered by testing if they were defined the current django project's own directory, there is no further need for testing if they are defined within a venv.