### PR TITLE
Fix missing PositiveBigIntegerField field error for django version < 3.1

### DIFF
--- a/django_typomatic/mappings.py
+++ b/django_typomatic/mappings.py
@@ -1,5 +1,7 @@
+import django
 from django.db.models import fields
 from rest_framework import serializers
+from packaging.version import Version
 
 mappings = {
     fields.AutoField: 'number',
@@ -19,7 +21,6 @@ mappings = {
     fields.GenericIPAddressField: 'string',
     fields.IPAddressField: 'string',
     fields.IntegerField: 'number',
-    fields.PositiveBigIntegerField: 'number',
     fields.PositiveIntegerField: 'number',
     fields.PositiveSmallIntegerField: 'number',
     fields.SlugField: 'string',
@@ -49,6 +50,10 @@ mappings = {
     serializers.TimeField: 'string',
     serializers.DurationField: 'string',
 }
+
+# PositiveBigIntegerField was added in Django 3.1
+if Version(django.__version__) >= Version('3.1'):
+    mappings[fields.PositiveBigIntegerField] = 'number'
 
 format_mappings = {
     serializers.EmailField: 'email',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django
 djangorestframework
 pytest
+packaging


### PR DESCRIPTION
`PositiveBigIntegerField` was only added to django in version 3.1 ([Source](https://docs.djangoproject.com/en/3.1/ref/models/fields/#positivebigintegerfield)) so using this (wonderful) package with a version of django <3.1 crashes with an error (`AttributeError: module 'django.db.models.fields' has no attribute 'PositiveBigIntegerField'. Did you mean: 'PositiveIntegerField'?`)

This PR should fix this! ✨ 

I just wish there was a good way to check a package version without adding a new dependency.