### PR TITLE
TypedDict introspection

### DIFF
--- a/django_typomatic/__init__.py
+++ b/django_typomatic/__init__.py
@@ -461,7 +461,7 @@ def __get_nested_serializer_field(
     return is_many, ts_type
 
 
-def __process_annotation(type: Type, debug=False) -> str:
+def __process_annotation(type, debug=False) -> str:
     retval = None
     type_name = getattr(type, "_name", None)
     if isinstance(type, dict):


### PR DESCRIPTION
TypedDict results from serialized methods can now return their type

I'm not an expert on type annotations, maybe other things have __annotations__, (maybe it's missing stuff too) but this worked for what i needed